### PR TITLE
Remove deprecated vues

### DIFF
--- a/CredentialCard.vue
+++ b/CredentialCard.vue
@@ -1,7 +1,7 @@
 <template>
   <q-card class="row br-credential-card bg-white q-ma-md">
     <div class="row justify-between items-center s-card-info-top">
-      <q-card-title class="s-card-info-top-text">
+      <q-card-section class="s-card-info-top-text">
         <q-item class="text-body1">
           <q-item-section>
             <q-item-label
@@ -16,12 +16,13 @@
             </q-item-label>
           </q-item-section>
         </q-item>
-      </q-card-title>
+      </q-card-section>
       <q-card-section class="s-logo">
         <q-icon
           v-if="useDefaultImage || !credential.issuerLogo"
           :name="defaultImage" />
-        <img v-else
+        <img
+          v-else
           :src="credential.issuerLogo"
           @error="imageError">
       </q-card-section>

--- a/CredentialCardDetail.vue
+++ b/CredentialCardDetail.vue
@@ -1,8 +1,8 @@
 <template>
   <q-card class="row br-credential-card">
-    <q-card-title class="text-center s-card-title">
+    <q-card-section class="text-center s-card-title">
       Credential Details
-    </q-card-title>
+    </q-card-section>
     <div class="row justify-between s-card-info">
       <div class="column items-center s-card-info-left">
         <q-card-section class="s-logo">
@@ -27,7 +27,9 @@
       </div>
       <div class="s-card-info-right">
         <div class="s-card-right-title">
-          <q-item multiline class="s-item">
+          <q-item
+            multiline
+            class="s-item">
             <q-item-label class="s-item-label">
               <q-item-section
                 class="text-subtitle1"

--- a/CredentialCardList.vue
+++ b/CredentialCardList.vue
@@ -38,7 +38,7 @@
             @error="imageError">
         </q-card-section>
       </div>
-      <q-card-separator />
+      <q-separator />
     </div>
 
     <div v-if="showFieldValues">

--- a/credentialMixin.js
+++ b/credentialMixin.js
@@ -9,6 +9,7 @@ const DEFAULT_ICONS = {
 
 export const credentialMixin = {
   beforeCreate() {
+    console.log(this.$q.iconSet.name);
     // set default icons
     const defaultIcons = DEFAULT_ICONS[this.$q.iconSet.name] ||
       DEFAULT_ICONS.fontawesome;

--- a/credentialMixin.js
+++ b/credentialMixin.js
@@ -9,16 +9,17 @@ const DEFAULT_ICONS = {
 
 export const credentialMixin = {
   beforeCreate() {
-    console.log(this.$q.iconSet.name);
     // set default icons
     const defaultIcons = DEFAULT_ICONS[this.$q.iconSet.name] ||
       DEFAULT_ICONS.fontawesome;
+    // if the iconSet is missing credentialCard add it.
     if(!this.$q.iconSet.credentialCard) {
       this.$q.iconSet.credentialCard = {};
     }
+    // add all the defaultIcons to credentialCard
     for(const name in defaultIcons) {
-      if(!this.$q.iconSet[name]) {
-        this.$q.iconSet[name] = defaultIcons[name];
+      if(!this.$q.iconSet.credentialCard[name]) {
+        this.$q.iconSet.credentialCard[name] = defaultIcons[name];
       }
     }
   },

--- a/main.less
+++ b/main.less
@@ -1,19 +1,4 @@
 /*
  * Copyright (c) 2018 Digital Bazaar, Inc. All rights reserved.
  */
-.br-credential-card {
-  & .q-collapsible-sub-item {
-    padding: 0;
-  }
 
-  & .q-collapsible-toggle-icon {
-    &.material-icons {
-      font-size: 32px;
-      margin-right: 4px;
-    }
-    &.fas {
-      font-size: 18px;
-      margin-right: 8px;
-    }
-  }
-}


### PR DESCRIPTION
Hey Josh,

Sorry about this, but I missed 2 deprecated components in this file q-card-title and q-card-seperator.
I replaced but with their respective replacements and I did notice one small thing:
<img width="737" alt="list-mode" src="https://user-images.githubusercontent.com/278280/54763148-11bbd200-4bbb-11e9-9957-2787841ee59c.png">
<img width="723" alt="list-mode-collapsed" src="https://user-images.githubusercontent.com/278280/54763683-07e69e80-4bbc-11e9-9766-0e0a83853a2e.png">


in list mode there is a small black line at the bottom of the component.
This appears to not be a result of the refactor.

One other thing I did notice:
q-collapsible -> q-expansion-item

has been deprecated. I could not find any use of q-collapsible in the project, but there is a css selector for it:
main.less lines 5 and 9

does that still need to be there?

anyways thanks for the amazing clean up and I should be able to use your code.
