### PR TITLE
Change how card recieves credential data.

### DIFF
--- a/CredentialCard.vue
+++ b/CredentialCard.vue
@@ -32,9 +32,9 @@
         <credential-card-field
           v-for="(value, key, index) in sliceFields(fieldQuantity)"
           :key="value"
-          :sublabels="schema[key].sublabels"
-          :name="schema[key].name"
-          :icon="schema[key].icon"
+          :sublabels="getSchema(key).sublabels"
+          :name="getSchema(key).name"
+          :icon="getSchema(key).icon"
           :value="value"
           :visible="showFieldValues"
           :visibility-toggle="visibilityToggle"

--- a/CredentialCard.vue
+++ b/CredentialCard.vue
@@ -23,7 +23,8 @@
         <slot name="image">
           <credential-card-image
             :show-default="!credential.issuerLogo"
-            :src="credential.issuerLogo" />
+            :src="credential.issuerLogo"
+            :default-icon="defaultIcon"/>
         </slot>
       </q-card-section>
     </div>

--- a/CredentialCardDetail.vue
+++ b/CredentialCardDetail.vue
@@ -16,7 +16,8 @@
           <slot name="image">
             <credential-card-image
               :show-default="!credential.issuerLogo"
-              :src="credential.issuerLogo" />
+              :src="credential.issuerLogo"
+              :default-icon="defaultIcon" />
           </slot>
         </q-card-section>
         <q-item-label class="s-issuer-info">

--- a/CredentialCardDetail.vue
+++ b/CredentialCardDetail.vue
@@ -56,9 +56,9 @@
             <credential-card-field
               v-for="(value, key) in fields"
               :key="value.id"
-              :name="schema[key].name"
-              :icon="schema[key].icon"
-              :sublabels="schema[key].sublabels"
+              :name="getSchema(key).name"
+              :icon="getSchema(key).icon"
+              :sublabels="getSchema(key).sublabels"
               :value="value"
               :visible="showFieldValues"
               :visibility-toggle="visibilityToggle"

--- a/CredentialCardField.vue
+++ b/CredentialCardField.vue
@@ -62,7 +62,7 @@
       <q-item-section
         v-if="!sublabels"
         class="g-field-data-regular">
-        {{value}}
+        {{objectCheck}}
       </q-item-section>
       <q-item-section
         v-else
@@ -161,7 +161,12 @@ export default {
       const primary = colors.getBrand('primary');
       const darker = colors.lighten(primary, -25);
       return darker;
-    }
+    },
+    objectCheck() {
+      if(!this.value.toString().startsWith('[object')) {
+        return this.value;
+      }
+    },
   },
   beforeCreate() {
     // set default icons

--- a/CredentialCardImage.vue
+++ b/CredentialCardImage.vue
@@ -36,7 +36,11 @@ export default {
       type: String,
       required: true,
       default: ''
-    }
+    },
+    defaultIcon: {
+      type: String,
+      required: false
+    },
   },
   data() {
     return {

--- a/CredentialCardList.vue
+++ b/CredentialCardList.vue
@@ -32,7 +32,8 @@
           <slot name="image">
             <credential-card-image
               :show-default="!credential.issuerLogo"
-              :src="credential.issuerLogo" />
+              :src="credential.issuerLogo"
+              :default-icon="defaultIcon"/>
           </slot>
         </q-card-section>
       </div>

--- a/CredentialCardList.vue
+++ b/CredentialCardList.vue
@@ -45,9 +45,9 @@
           <credential-card-field
             v-for="(value, key) in fields"
             :key="value"
-            :sublabels="schema[key].sublabels"
-            :name="schema[key].name"
-            :icon="schema[key].icon"
+            :sublabels="getSchema(key).sublabels"
+            :name="getSchema(key).name"
+            :icon="getSchema(key).icon"
             :value="value"
             :visible="showFieldValues"
             :visibility-toggle="visibilityToggle"

--- a/credentialMixin.js
+++ b/credentialMixin.js
@@ -65,6 +65,24 @@ export const credentialMixin = {
         acc[key] = value;
         return acc;
       }, {});
+    },
+    getSchema(val) {
+      let schema = '';
+      for(const key in this.schema) {
+        if(this.schema[key].icon) {
+          if(val === key) {
+            schema = this.schema[key];
+          }
+        }
+        else {
+          for(const value in this.schema[key]) {
+            if(val === value) {
+              schema = this.schema[key][value];
+            }
+          }
+        }
+      }
+      return schema;
     }
   }
 };
@@ -73,8 +91,15 @@ function _createFields(fields, source, schema) {
   for(const key in source) {
     // naively recurse into objects
     if(typeof source[key] === 'object') {
-      _createFields(fields, source[key], schema);
-      fields[key] = source[key];
+      for(const key in schema) {
+        if(schema[key].icon) {
+          _createFields(fields, source[key], schema);
+          fields[key] = source[key];
+        } else {
+          _createFields(fields, source[key], schema[key]);
+          fields[key] = source[key];
+        }
+      }
     } else if(schema[key]) {
       // field defined in schema, add it
       fields[key] = source[key];

--- a/test/components/Home.vue
+++ b/test/components/Home.vue
@@ -65,6 +65,12 @@ export default {
           id: 'did:v1:test:1234',
           name: 'John Doe',
           email: 'john.doe@test.com',
+          organizationRegistration: {
+            id: 'id',
+            status: 'status',
+            registrar: 'registrar',
+            created: 'created'
+          },
           address: {
             streetAddress: '123 Main St.',
             addressCountry: 'US',
@@ -98,6 +104,24 @@ export default {
           name: 'Address',
           icon: 'fa fa-map-marker-alt',
           sublabels: true
+        },
+        organizationRegistration: {
+          id: {
+            name: 'ID',
+            icon: 'fas fa-fingerprint'
+          },
+          status: {
+            name: 'Status',
+            icon: 'fa fa-info'
+          },
+          registrar: {
+            name: 'Registrar',
+            icon: 'fa fa-clipboard-check'
+          },
+          created: {
+            name: 'Created',
+            icon: 'far fa-clock'
+          },
         }
       }
     };


### PR DESCRIPTION
-Adds to ability for credential card to read the data formatted like the following:

organizationRegistration: {
id: 'id', 
status: 'status', 
registrar: 'registrar', 
created: 'created'
},

This new format allows for each field to have their own icons.

![Screen Shot 2019-04-10 at 1 05 00 PM](https://user-images.githubusercontent.com/22648574/55902511-4b1ba800-5b91-11e9-98b5-3933ed157a13.png)

This implementation may not be the best and would like suggestions on how it can be improved/refactored to be more efficient.