### PR TITLE
Update quasar dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # bedrock-vue-credential-card ChangeLog
 
-## 6.0.2 - 2024-xx-xx
+## 7.0.0 - 2024-xx-xx
 
 ### Changed
 - Update lint tooling.
+- **BREAKING**: Update dependencies.
+  - `@bedrock/quasar@10`.
 
 ## 6.0.1 - 2022-08-22
 

--- a/components/CredentialCardField.vue
+++ b/components/CredentialCardField.vue
@@ -128,9 +128,9 @@
 
 <script>
 /*!
- * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2024 Digital Bazaar, Inc. All rights reserved.
  */
-import Quasar from 'quasar';
+import {colors, getCssVar} from 'quasar';
 
 const DEFAULT_ICONS = {
   fontawesome: {
@@ -201,15 +201,13 @@ export default {
       return this.$q.iconSet.credentialCardField.hideField;
     },
     visibleBackgroundColor() {
-      const {utils: {colors}} = Quasar;
-      const primary = colors.getBrand('primary');
+      const primary = getCssVar('primary');
       const rgba = colors.hexToRgb(primary);
       rgba.a = 0.15;
       return `rgba(${rgba.r}, ${rgba.g}, ${rgba.b}, ${rgba.a})`;
     },
     darkerPrimary() {
-      const {utils: {colors}} = Quasar;
-      const primary = colors.getBrand('primary');
+      const primary = getCssVar('primary');
       const darker = colors.lighten(primary, -25);
       return darker;
     },

--- a/package.json
+++ b/package.json
@@ -15,10 +15,6 @@
   "scripts": {
     "lint": "eslint --ext .cjs,.js,.vue ."
   },
-  "peerDependencies": {
-    "@bedrock/quasar": "^9.0.0",
-    "vue": "^3.2.36"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/digitalbazaar/bedrock-vue-credential-card"
@@ -35,6 +31,10 @@
     "url": "https://github.com/digitalbazaar/bedrock-vue-credential-card/issues"
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-vue-credential-card",
+  "peerDependencies": {
+    "@bedrock/quasar": "^10.0.0",
+    "vue": "^3.2.36"
+  },
   "devDependencies": {
     "eslint": "^8.57.0",
     "eslint-config-digitalbazaar": "^5.0.1",

--- a/test/components/index.js
+++ b/test/components/index.js
@@ -1,12 +1,12 @@
 /*!
- * Copyright (c) 2018-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as brQuasar from '@bedrock/quasar';
 import * as brVue from '@bedrock/vue';
 // import {config} from '@bedrock/web';
 import {createRouter, createWebHistory} from 'vue-router';
-import {default as iconSet} from 'quasar/icon-set/fontawesome-v5.js';
-import Quasar from 'quasar';
+import iconSet from 'quasar/icon-set/fontawesome-v5.mjs';
+import {Quasar} from 'quasar';
 import TestApp from '../components/TestApp.vue';
 
 import './app.less';

--- a/test/package.json
+++ b/test/package.json
@@ -33,7 +33,7 @@
     "@bedrock/core": "^6.0.1",
     "@bedrock/express": "^8.0.0",
     "@bedrock/karma": "^6.0.0",
-    "@bedrock/quasar": "^9.0.0",
+    "@bedrock/quasar": "^10.0.0",
     "@bedrock/server": "^5.0.0",
     "@bedrock/test": "^8.0.5",
     "@bedrock/views": "^11.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@bedrock/core": "^6.0.1",
     "@bedrock/express": "^8.0.0",
-    "@bedrock/karma": "^6.0.0",
+    "@bedrock/karma": "^7.0.1",
     "@bedrock/quasar": "^10.0.0",
     "@bedrock/server": "^5.0.0",
     "@bedrock/test": "^8.0.5",

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -17,8 +17,6 @@ config.karma.config.proxyValidateSSL = false;
 
 // TODO: consider moving to `bedrock-karma`?
 config.karma.config.webpack.resolve = {
-  alias: {
-    quasar$: path.resolve(
-      __dirname, 'node_modules/quasar/dist/quasar.umd.js')
-  }
+  // ensure peer deps can be found in test `node_modules` dir
+  modules: [path.resolve(__dirname, 'node_modules')]
 };

--- a/test/web/10-CredentialCard.js
+++ b/test/web/10-CredentialCard.js
@@ -1,19 +1,35 @@
 /*!
  * Copyright (c) 2018-2024 Digital Bazaar, Inc. All rights reserved.
  */
+import {createApp} from 'vue';
 import {CredentialCard} from '@bedrock/vue-credential-card';
-import Vue from 'vue';
+import iconSet from 'quasar/icon-set/fontawesome-v5.mjs';
+import {Quasar} from 'quasar';
+
+function tearDown(app) {
+  return app.unmount();
+}
+
+function _createApp({propsData = {}}) {
+  const app = createApp(CredentialCard, propsData);
+  app.use(Quasar);
+  Quasar.iconSet.set(iconSet);
+  return app;
+}
 
 // helper function that mounts and returns the rendered text
-function renderCredentialCard(propsData) {
-  const Constructor = Vue.extend(CredentialCard);
-  return new Constructor({propsData}).$mount();
+function renderCredentialCard({app = null, propsData = {}}) {
+  if(!app) {
+    app = _createApp({propsData});
+  }
+  const vm = app.mount('*');
+  return {app, vm};
 }
 
 describe('CredentialCard', () => {
   it('should render content if type of value is a string in credential ' +
     'subject', async () => {
-    const vm = renderCredentialCard({
+    const {app, vm} = renderCredentialCard({propsData: {
       credential: {
         credentialSubject: {
           name: 'John Doe',
@@ -28,11 +44,12 @@ describe('CredentialCard', () => {
           icon: 'fas fa-user'
         }
       }
-    });
+    }});
     should.exist(vm);
     should.exist(vm.$el);
     vm.$el.querySelector('.g-field-data-regular')
       .textContent.trim().should.equal('John Doe');
+    tearDown(app);
   });
 
   it('should not render content if type of value in credential ' +
@@ -40,7 +57,7 @@ describe('CredentialCard', () => {
     const valueTypes = [undefined, null];
 
     for(const value of valueTypes) {
-      const vm = renderCredentialCard({
+      const {app, vm} = renderCredentialCard({propsData: {
         credential: {
           credentialSubject: {
             name: value,
@@ -55,10 +72,11 @@ describe('CredentialCard', () => {
             icon: 'fas fa-user'
           }
         }
-      });
+      }});
       should.exist(vm);
       should.exist(vm.$el);
       should.not.exist(vm.$el.querySelector('.g-field-data-regular'));
+      tearDown(app);
     }
   });
 
@@ -67,7 +85,7 @@ describe('CredentialCard', () => {
     const valueTypes = [ NaN, 0, false];
 
     for(const value of valueTypes) {
-      const vm = renderCredentialCard({
+      const {app, vm} = renderCredentialCard({propsData: {
         credential: {
           credentialSubject: {
             name: value,
@@ -82,15 +100,16 @@ describe('CredentialCard', () => {
             icon: 'fas fa-user'
           }
         }
-      });
+      }});
       should.exist(vm);
       should.exist(vm.$el);
       should.exist(vm.$el.querySelector('.g-field-data-regular'));
+      tearDown(app);
     }
   });
   it('should render content if type of value in credential ' +
     'subject is an object', async () => {
-    const vm = renderCredentialCard({
+    const {app, vm} = renderCredentialCard({propsData: {
       credential: {
         credentialSubject: {
           address: {
@@ -112,9 +131,10 @@ describe('CredentialCard', () => {
           sublabels: true
         }
       }
-    });
+    }});
     should.exist(vm);
     should.exist(vm.$el);
     should.exist(vm.$el.querySelector('.g-field-data-regular'));
+    tearDown(app);
   });
 });

--- a/test/web/10-CredentialCard.js
+++ b/test/web/10-CredentialCard.js
@@ -41,13 +41,14 @@ describe('CredentialCard', () => {
       schema: {
         name: {
           name: 'Full Name',
-          icon: 'fas fa-user'
+          icon: 'fas fa-user',
+          valueMapper: name => name
         }
       }
     }});
     should.exist(vm);
     should.exist(vm.$el);
-    vm.$el.querySelector('.g-field-data-regular')
+    vm.$el.querySelector('.g-field-data-regular div:nth-child(2)')
       .textContent.trim().should.equal('John Doe');
     tearDown(app);
   });


### PR DESCRIPTION
- Untested in a real app. Help needed.
- Tests were not being run so the one that failed may have been stale?  The default `valueMapper` returns undefined (seems an odd choice), so seems `name` needs a passthrough mapper.  And the selector for the rendered output looks like it should pick the content of the div with the `displayValue`.